### PR TITLE
refactor(twitch.data.js)

### DIFF
--- a/.vitepress/theme/components/TwitchList.vue
+++ b/.vitepress/theme/components/TwitchList.vue
@@ -2,10 +2,9 @@
 import { data } from "./loaders/twitch.data.js";
 import { ref } from "vue";
 import { onMounted } from "vue";
-import {forEach} from "lodash";
 
 let input = ref("");
-let channels = data
+let channels = data;
 
 /**
  * Simple call for loading the channel link in a new tab.
@@ -48,6 +47,10 @@ function updateStreamStatus(status) {
  * CLIENT SIDE
  */
 onMounted(async () => {
+	if (channels.length === 0) {
+		return;
+	}
+
 	let response = await fetch(`https://twitchstatusbulk.ingramscloud.workers.dev/`, {
 		method: "POST",
 		body: JSON.stringify(channels),
@@ -56,6 +59,7 @@ onMounted(async () => {
 			"content-type": "application/json",
 		},
 	})
+
 	let data = await response.json()
 	data.forEach((channel) => { updateStreamStatus(channel); });
 });
@@ -67,23 +71,26 @@ onMounted(async () => {
 		<input class="search" type="text" v-model="input" placeholder="Search tags..." />
 	</div>
 	<div class="twitch-list">
-		<div v-bind:id="'channel_' + channel.accountname" :key="channel" class="channel" v-for="channel in filteredlist()" @click="openPage(channel.url)">
-			<div v-bind:id="'livetag_' + channel.accountname" style="display: none" class="livelabel">LIVE</div>
-			<div class="channelcontent">
-				<img
-					v-bind:id="'pfp_' + channel.accountname"
-					v-bind:src="channel.profile_url" />
-				<div class="title">
-					<div v-bind:id="'title_' + channel.accountname" v-if="channel.fc == null" class="name">{{ channel.name }}</div>
-					<div v-bind:id="'title_' + channel.accountname" v-if="channel.fc != null" class="name">{{ channel.name }} <span class="fc">«{{ channel.fc }}»</span></div>
-					<div v-bind:id="'tags_' + channel.accountname" class="tags"># {{ channel.tags }}</div>
-				</div>
-				<div class="details">
-					<div class="days">{{ channel.streamdays }}</div>
-					<div class="server">{{ channel.server }}</div>
+		<template v-if="channels.length > 0">
+			<div v-bind:id="'channel_' + channel.accountname" :key="channel" class="channel" v-for="channel in filteredlist()" @click="openPage(channel.url)">
+				<div v-bind:id="'livetag_' + channel.accountname" style="display: none" class="livelabel">LIVE</div>
+				<div class="channelcontent">
+					<img
+						v-bind:id="'pfp_' + channel.accountname"
+						v-bind:src="channel.profile_url" />
+					<div class="title">
+						<div v-bind:id="'title_' + channel.accountname" v-if="channel.fc == null" class="name">{{ channel.name }}</div>
+						<div v-bind:id="'title_' + channel.accountname" v-if="channel.fc != null" class="name">{{ channel.name }} <span class="fc">«{{ channel.fc }}»</span></div>
+						<div v-bind:id="'tags_' + channel.accountname" class="tags"># {{ channel.tags }}</div>
+					</div>
+					<div class="details">
+						<div class="days">{{ channel.streamdays }}</div>
+						<div class="server">{{ channel.server }}</div>
+					</div>
 				</div>
 			</div>
-		</div>
+		</template>
+		<p v-else>Unable to fetch channels.</p>
 	</div>
 </template>
 

--- a/.vitepress/theme/components/loaders/twitch.data.js
+++ b/.vitepress/theme/components/loaders/twitch.data.js
@@ -32,8 +32,15 @@ export default {
 		}
 
 		return await Promise.all(channels.map(async channel => {
-			const userInfo = await fetch(`https://twitchuserinfo.ingramscloud.workers.dev/${channel.accountname}`).then(res => res.json());
-			return { ...channel, profile_url: userInfo.profile_url };
+			try {
+				const userInfo = await fetch(`https://twitchuserinfo.ingramscloud.workers.dev/${channel.accountname}`)
+					.then(res => res.json());
+				return { ...channel, profile_url: userInfo.profile_url };
+			} catch (error) {
+				// Return channel as is if fetch fails (needed for banned or suspended accounts)
+				console.error(`Failed to fetch user info for ${channel.accountname}:`, error);
+				return { ...channel };
+			}
 		}));
 	}
 };

--- a/.vitepress/theme/components/loaders/twitch.data.js
+++ b/.vitepress/theme/components/loaders/twitch.data.js
@@ -1,4 +1,9 @@
 export default {
+
+	/**
+	 * @returns {Object[]} An array of channel objects.
+	 */
+
 	async load() {
 		const sheetURL = 'https://docs.google.com/spreadsheets/u/0/d/1xsugAiw0j3Kz0Ic41gD-QuMtfxiVtlf-mujLC3Xt78c/gviz/tq?tqx=out:json&sheet=twitch';
 		const defaultPicURL = 'https://static-cdn.jtvnw.net/user-default-pictures-uv/cdd517fe-def4-11e9-948e-784f43822e80-profile_image-70x70.png';

--- a/.vitepress/theme/components/loaders/twitch.data.js
+++ b/.vitepress/theme/components/loaders/twitch.data.js
@@ -4,10 +4,17 @@ export default {
 		const defaultPicURL = 'https://static-cdn.jtvnw.net/user-default-pictures-uv/cdd517fe-def4-11e9-948e-784f43822e80-profile_image-70x70.png';
 
 		// Fetches the channel list from google sheets
-		const sheet = JSON.parse((await (await fetch(sheetURL)).text())
-			.replace("/*O_o*/\ngoogle.visualization.Query.setResponse(", "")
-			.slice(0, -2)
-		);
+		try {
+			const response = await fetch(sheetURL);
+			const text = await response.text();
+			var sheet = JSON.parse(text
+				.replace("/*O_o*/\ngoogle.visualization.Query.setResponse(", "")
+				.slice(0, -2)
+			);
+		} catch (error) {
+			console.log("Failed to fetch sheet:", error);
+			return [];
+		}
 
 		// Compile the google sheet data into an object array
 		const channels = sheet.table.rows.slice(1).reduce((acc, row) => {
@@ -33,8 +40,8 @@ export default {
 
 		return await Promise.all(channels.map(async channel => {
 			try {
-				const userInfo = await fetch(`https://twitchuserinfo.ingramscloud.workers.dev/${channel.accountname}`)
-					.then(res => res.json());
+				const response = await fetch(`https://twitchuserinfo.ingramscloud.workers.dev/${channel.accountname}`);
+				const userInfo = await response.json();
 				return { ...channel, profile_url: userInfo.profile_url };
 			} catch (error) {
 				// Return channel as is if fetch fails (needed for banned or suspended accounts)


### PR DESCRIPTION
- Simplified `profile_url` setting/fetching
- Added error handling to sheet fetch, returns an empty array on error; `TwitchList.vue` can handle the empty array by displaying a fallback message (e.g. Unable to fetch channels) or whatever 